### PR TITLE
Fix directory seperator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,11 @@
         "test-coverage": "vendor/bin/pest --coverage"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "phpstan/extension-installer": true
+        }
     },
     "extra": {
         "laravel": {

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -25,10 +25,10 @@ class DeployCommand extends Command
         $force = $this->option('force');
 
         $lighthouse = config('lighthouse.schema.register');
-        $local = base_path('vendor\kallefrombosnia\twill-graphql\src\schema.graphql');
+        $local = base_path('vendor/kallefrombosnia/twill-graphql/src/schema.graphql');
         
-        $local_twill = base_path('vendor\kallefrombosnia\twill-graphql\src\twill.graphql');
-        $distant_twill = base_path('graphql\twill.graphql');
+        $local_twill = base_path('vendor/kallefrombosnia/twill-graphql/src/twill.graphql');
+        $distant_twill = base_path('graphql/twill.graphql');
 
         // Check if lighthouse config is submitted
         if(!$lighthouse){


### PR DESCRIPTION
Previous code contained Win-based `\` directory separators. 
This fix uses `/` as all environments support it.